### PR TITLE
Match leading/trailing underscores in component.css reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can submit your style in the following way:
 	</section>
 ```
 3. Choose a Shakespeare character name as title and replace it with "yourstyle" (id, title, menu--[name])
-4. Add your styles to the ___component.css__ right before the media query. Please don't forget the -webkit- prefixed properties where necessary.
+4. Add your styles to the ___component.css___ right before the media query. Please don't forget the -webkit- prefixed properties where necessary.
 5. Add your name and social/website link to the info paragraph.
 6. Please credit if you base your style on an existing design. You can do so by adding a paragraph with the class `info` after your menu. 
 


### PR DESCRIPTION
Before, the leading/trailing underscores for "component.css" were mismatched, causing it to look like:

___component.css__

This change matches the underscores to make it look like:

**_component.css**_
