### PR TITLE
Remove trailing spaces in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An open collection of menu styles that use the line as a creative design element
 _Please don't add any other changes to a pull request for new styles. If you want to contribute some other updates to the repo, make sure to add those in a different pull request._
 
 You can submit your style in the following way:
-1. Fork this repo 
+1. Fork this repo
 2. Copy the following snippet and insert it before the dummy section:
 ```html
 	<section class="section section--menu" id="Yourstyle">
@@ -32,7 +32,7 @@ You can submit your style in the following way:
 3. Choose a Shakespeare character name as title and replace it with "yourstyle" (id, title, menu--[name])
 4. Add your styles to the ___component.css__ right before the media query. Please don't forget the -webkit- prefixed properties where necessary.
 5. Add your name and social/website link to the info paragraph.
-6. Please credit if you base your style on an existing design. You can do so by adding a paragraph with the class `info` after your menu. 
+6. Please credit if you base your style on an existing design. You can do so by adding a paragraph with the class `info` after your menu.
 
 _Please test your styles in the latest stable releases of all common browsers (Chrome, Safari, Firefox, IE), preferrable on Win and Mac and mobile if possible._
 
@@ -40,7 +40,7 @@ __We'll carefully select the best styles.__
 
 ## License
 
-Integrate or build upon it for free in your personal or commercial projects. Don't republish, redistribute or sell "as-is". 
+Integrate or build upon it for free in your personal or commercial projects. Don't republish, redistribute or sell "as-is".
 
 Read more here: [License](http://tympanus.net/codrops/licensing/)
 


### PR DESCRIPTION
My editor fixed this automatically in https://github.com/codrops/LineMenuStyles/pull/1. Figured it was worth a PR since it might happen to other contributors.
