### PR TITLE
Allow to use via bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,22 @@
+{
+  "name": "line-menu-styles",
+  "homepage": "https://github.com/codrops/LineMenuStyles",
+  "authors": [
+    "Codrops <http://www.codrops.com/>"
+  ],
+  "description": "An open collection of menu styles that use the line as creative design element. http://tympanus.net/Development/LineMenuStyles/",
+  "main": "README.md",
+  "moduleType": [],
+  "keywords": [
+    "line",
+    "menu",
+    "style",
+    "css",
+    "js"
+  ],
+  "license": "http://tympanus.net/codrops/licensing/",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:codrops/LineMenuStyles.git"
+  }
+}


### PR DESCRIPTION
We would like to use this library via bower `bower install line-menu-styles`

If merged, we would need to do `bower register line-menu-styles git@github.com:codrops/LineMenuStyles.git`.

A tag 1.0.0 would be much appreciated.

Keep up the good work !
